### PR TITLE
Enhance CLI with rich output and improved exceptions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -221,6 +221,43 @@ files = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
 name = "mypy"
 version = "1.16.1"
 description = "Optional static typing for Python"
@@ -350,7 +387,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -402,6 +439,26 @@ pytest = ">=6.2.5"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.8.0"
+groups = ["main"]
+files = [
+    {file = "rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0"},
+    {file = "rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruff"
@@ -480,13 +537,14 @@ version = "4.14.1"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
     {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
 ]
+markers = {main = "python_version == \"3.10\""}
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "aedd07a8d8c3580ac659f39bbad4f2b19453226e2c181996ecdc1654a41c8120"
+content-hash = "dd97620693ea86209fdce382e3707c5c6f283fcee23d696bb45d585beaa133cf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ packages = [{ include = "cuddly_potato" }]
 [tool.poetry.dependencies]
 python = "^3.10"
 Click = "*"
+rich = "*"
 customtkinter = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Click",
+        "rich",
         "customtkinter",
     ],
     entry_points={

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ class TestCli(unittest.TestCase):
             ],
         )
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("Entry added successfully.", result.output)
+        self.assertIn("Entry added successfully!", result.output)
 
     def test_add_command_interactive(self):
         """Test the 'add' command works with interactive prompts."""
@@ -51,7 +51,7 @@ class TestCli(unittest.TestCase):
         )
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("Entry added successfully.", result.output)
+        self.assertIn("Entry added successfully!", result.output)
         self.assertIn("Interactive Q", result.output)
 
     def test_update_command(self):
@@ -66,7 +66,7 @@ class TestCli(unittest.TestCase):
         )
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("Entry updated successfully.", result.output)
+        self.assertIn("Entry 1 updated successfully!", result.output)
 
     def test_export_command(self):
         """Test that the 'export' command creates a valid JSON file."""

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,7 +2,13 @@ import unittest
 import sqlite3
 import os
 import json
-from cuddly_potato.database import create_table, add_entry, update_entry, export_to_json
+from cuddly_potato.database import (
+    create_table,
+    add_entry,
+    update_entry,
+    export_to_json,
+    DatabaseError,
+)
 
 
 class TestDatabase(unittest.TestCase):
@@ -22,7 +28,7 @@ class TestDatabase(unittest.TestCase):
 
     def test_add_entry(self):
         """Test adding a new entry."""
-        result = add_entry(
+        add_entry(
             self.conn,
             "What is 2 + 2?",
             "TestModel",
@@ -31,7 +37,6 @@ class TestDatabase(unittest.TestCase):
             "Basic Math",
             "A test entry",
         )
-        self.assertEqual(result, "Entry added successfully.")
 
         cursor = self.conn.cursor()
         cursor.execute("SELECT * FROM Youtubes WHERE question = ?", ("What is 2 + 2?",))
@@ -52,16 +57,16 @@ class TestDatabase(unittest.TestCase):
             "Basic Math",
             "First entry",
         )
-        result = add_entry(
-            self.conn,
-            "What is 2 + 2?",
-            "TestModel",
-            "4.0",
-            "Math",
-            "Basic Math",
-            "Second entry",
-        )
-        self.assertEqual(result, "Error: This question for this model already exists.")
+        with self.assertRaises(DatabaseError):
+            add_entry(
+                self.conn,
+                "What is 2 + 2?",
+                "TestModel",
+                "4.0",
+                "Math",
+                "Basic Math",
+                "Second entry",
+            )
 
     def test_update_entry(self):
         """Test updating an existing entry."""
@@ -79,7 +84,7 @@ class TestDatabase(unittest.TestCase):
         cursor.execute("SELECT id FROM Youtubes WHERE question = 'Old Question'")
         entry_id = cursor.fetchone()["id"]
 
-        result = update_entry(
+        update_entry(
             self.conn,
             entry_id,
             "New Question",
@@ -89,7 +94,6 @@ class TestDatabase(unittest.TestCase):
             "NewSub",
             "NewComment",
         )
-        self.assertEqual(result, "Entry updated successfully.")
 
         cursor.execute("SELECT * FROM Youtubes WHERE id = ?", (entry_id,))
         entry = cursor.fetchone()
@@ -99,10 +103,8 @@ class TestDatabase(unittest.TestCase):
 
     def test_update_nonexistent_entry(self):
         """Test updating an entry that does not exist."""
-        result = update_entry(
-            self.conn, 999, "New Question", None, None, None, None, None
-        )
-        self.assertEqual(result, "Error: No entry found with id 999.")
+        with self.assertRaises(DatabaseError):
+            update_entry(self.conn, 999, "New Question", None, None, None, None, None)
 
     def test_export_to_json(self):
         """Test exporting data to a JSON file."""
@@ -110,9 +112,8 @@ class TestDatabase(unittest.TestCase):
         add_entry(self.conn, "Q2", "M2", "A2", "D2", "S2", "C2")
 
         json_path = "test_export.json"
-        result = export_to_json(self.conn, json_path)
+        export_to_json(self.conn, json_path)
 
-        self.assertEqual(result, f"Data exported to {json_path}")
         self.assertTrue(os.path.exists(json_path))
 
         os.remove(json_path)
@@ -126,7 +127,7 @@ class TestDatabase(unittest.TestCase):
 
     def test_add_entry_with_missing_optional_fields(self):
         """Test adding an entry with only the required fields."""
-        result = add_entry(
+        add_entry(
             self.conn,
             "Required only?",
             "TestModel",
@@ -135,7 +136,6 @@ class TestDatabase(unittest.TestCase):
             None,
             None,
         )
-        self.assertEqual(result, "Entry added successfully.")
 
         cursor = self.conn.cursor()
         cursor.execute(
@@ -164,7 +164,7 @@ class TestDatabase(unittest.TestCase):
         cursor.execute("SELECT id FROM Youtubes WHERE question = 'Initial Q'")
         entry_id = cursor.fetchone()["id"]
 
-        result = update_entry(
+        update_entry(
             self.conn,
             entry_id,
             None,
@@ -174,7 +174,6 @@ class TestDatabase(unittest.TestCase):
             None,
             None,
         )
-        self.assertEqual(result, "Entry updated successfully.")
 
         cursor.execute("SELECT * FROM Youtubes WHERE id = ?", (entry_id,))
         entry = cursor.fetchone()
@@ -191,27 +190,23 @@ class TestDatabase(unittest.TestCase):
         cursor.execute("SELECT id FROM Youtubes WHERE question = 'Unique Q2'")
         entry_id_to_update = cursor.fetchone()["id"]
 
-        result = update_entry(
-            self.conn,
-            entry_id_to_update,
-            "Unique Q1",
-            "ModelA",
-            "A3",
-            None,
-            None,
-            None,
-        )
-        self.assertEqual(
-            result,
-            "Error: Update would create a duplicate question for the same model.",
-        )
+        with self.assertRaises(DatabaseError):
+            update_entry(
+                self.conn,
+                entry_id_to_update,
+                "Unique Q1",
+                "ModelA",
+                "A3",
+                None,
+                None,
+                None,
+            )
 
     def test_export_to_json_empty_db(self):
         """Test exporting an empty database results in an empty JSON list."""
         json_path = "test_empty_export.json"
-        result = export_to_json(self.conn, json_path)
+        export_to_json(self.conn, json_path)
 
-        self.assertEqual(result, f"Data exported to {json_path}")
         self.assertTrue(os.path.exists(json_path))
 
         with open(json_path, "r") as f:


### PR DESCRIPTION
## Summary
- add `rich` dependency
- implement `DatabaseError` and update DB functions
- show colored messages using rich in CLI
- update tests for new behavior
- lock updated dependencies

## Testing
- `poetry install`
- `./scripts/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_686cbfce1a088322912d480ac5dcd4f6